### PR TITLE
remove closing php tags, add blank line before namespace

### DIFF
--- a/src/FlagData.php
+++ b/src/FlagData.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace phputil\flags;
 
 class FlagData {
@@ -24,5 +25,3 @@ class FlagData {
         return $this;
     }
 }
-
-?>

--- a/src/FlagException.php
+++ b/src/FlagException.php
@@ -1,5 +1,5 @@
 <?php
+
 namespace phputil\flags;
 
 class FlagException extends \RuntimeException {}
-?>

--- a/src/FlagListener.php
+++ b/src/FlagListener.php
@@ -1,8 +1,7 @@
 <?php
+
 namespace phputil\flags;
 
 interface FlagListener {
     public function notify( string $event, FlagData $flag ): void;
 }
-
-?>

--- a/src/FlagListeners.php
+++ b/src/FlagListeners.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace phputil\flags;
 
 class FlagListeners {
@@ -45,4 +46,3 @@ class FlagListeners {
         }
     }
 }
-?>

--- a/src/FlagManager.php
+++ b/src/FlagManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace phputil\flags;
 
 const CHANGE_EVENT = 'changed';

--- a/src/FlagMetadata.php
+++ b/src/FlagMetadata.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace phputil\flags;
 
 use DateTime;
@@ -40,4 +41,3 @@ class FlagMetadata {
         $this->accessCount++;
     }
 }
-?>

--- a/src/FlagStorage.php
+++ b/src/FlagStorage.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace phputil\flags;
 
 interface FlagStorage {
@@ -84,4 +85,3 @@ interface FlagStorage {
     public function count( array $options = [] ): int;
 
 }
-?>

--- a/src/FlagVerificationStrategy.php
+++ b/src/FlagVerificationStrategy.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace phputil\flags;
 
 interface FlagVerificationStrategy {
     public function isEnabled( string $key ): bool;
 }
-?>

--- a/src/storages/InMemoryStorage.php
+++ b/src/storages/InMemoryStorage.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace phputil\flags;
 
 /**
@@ -65,5 +66,4 @@ class InMemoryStorage implements FlagStorage {
     public function count( array $options = [] ): int {
         return count( $this->flags );
     }
-
 }

--- a/src/strategies/StorageBasedVerificationStrategy.php
+++ b/src/strategies/StorageBasedVerificationStrategy.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace phputil\flags;
 
 /**


### PR DESCRIPTION

Removed closing PHP tags. Noticed some files already had this change.

Also added a blank line at the start of files.

Separately....

I fully understand there can be personal preferences to how whitespace is used. i have my own preferences for things like constants where TRUE and FALSE are always written in uppercase when used as a value.

Do you prefer and insist on spaces for the function argument lists?

```php
<?php

namespace phputil\flags;

interface FlagListener {
    public function notify( string $event, FlagData $flag ): void;
}
```

Accepted PHP standards say that there should be no spaces around the parentheses.

```php
public function notify(string $event, FlagData $flag): void;
```

But I understand if you prefer it being left the way you wrote it. Habits can be hard to break. 
